### PR TITLE
Fixed float bug

### DIFF
--- a/index.php
+++ b/index.php
@@ -148,7 +148,7 @@ ImageFilledRectangle($scimage, 0, 56, $width, $height, $bottomColor);
 
 // 各種文字描画
 imagettftext($scimage, 10, 0, 72, 8 + 11, $nameFontColor, $notosansjpFontFile, $name);
-imagettftext($scimage, 11, 0, 72, 8 + 11 + 14 + 5, $moneyFontColor, $notosansjpFontFile, '￥' . number_format($money));
+imagettftext($scimage, 11, 0, 72, 8 + 11 + 14 + 5, $moneyFontColor, $notosansjpFontFile, '￥' . number_format((float)$money));
 
 // 本文描画
 $i = count($textArr) - 1;


### PR DESCRIPTION
こちらのリポジトリに興味がわき、実行してみたところ、エラーが出て実行できませんでした。環境は、Windows 11のXAMPPです。

エラーは、「151行目の$money変数はstring型でありfloat型ではない」とのことで、float型に変換するための「(float)」という文字列を追加し修正しました。

余計なお世話でしたらごめんなさい。

I was interested in this repository and tried to run it, but was unable to do so due to an error. The environment is XAMPP on Windows 11.

The error was "The $money variable on line 151 is a string type and not a float type", so I fixed it by adding the string "(float)" to convert it to a float type.

Sorry if this is unnecessary.